### PR TITLE
Fix/order grouping

### DIFF
--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -314,7 +314,12 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
                     $this->getDriverEscaper()->dbCommand('WHERE') . ' ' .
                     $language . ' ' .
                     $this->getDriverEscaper()->reserved('predicate') . ' = ' .
-                    $this->getDriverEscaper()->quote($alias['predicate']) . ' ) ' .
+                    $this->getDriverEscaper()->quote($alias['predicate']) . ' ' .
+                    $this->getDriverEscaper()->dbCommand('GROUP') . ' '.
+                    $this->getDriverEscaper()->dbCommand('BY') . ' ' .
+                    $this->getDriverEscaper()->reserved('subject') .
+                    $this->getDriverEscaper()->getFieldsSeparator() .
+                    $this->getDriverEscaper()->reserved('object') . ' ) ' .
                     $this->getDriverEscaper()->dbCommand('AS') . ' ' .
                     $alias['name'] . ' ' . $this->getDriverEscaper()->dbCommand('ON') . ' ( ' .
                     $this->getDriverEscaper()->reserved('mainq') . '.' .


### PR DESCRIPTION
To reproduce it try to make a query with order by property which is set twice or more for resource (for example `http://www.tao.lu/Ontologies/generis.rdf#userRoles` which may be more than one for user). Return value will have the same amount of duplicates of this resource as there was values of this property. 