### PR TITLE
remove string `object` from order block in search query

### DIFF
--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -179,7 +179,7 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
             $this->query .=  $this->getDriverEscaper()->dbCommand('AND') . ' '.
                 $this->getDriverEscaper()->reserved('modelid') . ' '.
                 $this->getDriverEscaper()->dbCommand('IN') . ' '.
-                "('" . implode("','", $this->model->getReadableModels()) . "')".
+                '(' . implode(',', $this->model->getReadableModels()) . ')'.
                 $this->operationSeparator ;
         }
         $this->query .= ' )'.')';
@@ -264,7 +264,7 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
         foreach ($aliases as $alias) {
             $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
                     $this->getDriverEscaper()->reserved('object') . ' ' .
-                    $this->getDriverEscaper()->dbCommand('AS') . ' ' . $alias['name'] . '_field';
+                    $this->getDriverEscaper()->dbCommand('AS') . ' ' . $alias['name'];
         }
 
         $result .= implode($this->getDriverEscaper()->getFieldsSeparator(), $sortFields)

--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -285,9 +285,8 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
         $sortFields = [];
 
         foreach ($aliases as $alias) {
-            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
-                    $this->getDriverEscaper()->reserved('object') . ' ' .
-                    $alias['dir'] . $this->operationSeparator;
+            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . ' '
+                . $alias['dir'] . $this->operationSeparator;
         }
 
         $result = $this->getDriverEscaper()->dbCommand('ORDER BY') . ' ' .


### PR DESCRIPTION
When listing items or test in back office interface we get an error:

```
{
    "message": "
    Cannot access field object on a value with type STRING [at 1:629]\\n...mainq.subject = orderq1.subject) ORDER BY orderq1.object asc  ) AS rootq  \\n                                                     ^",
    "code": 3,
    "status": "INVALID_ARGUMENT",
    "details": [
        {
            "@type": "google.rpc.localizedmessage-bin",
            "locale": "en-US",
            "message": "Cannot access field object on a value with type STRING [at 1:629]\n...mainq.subject = orderq1.subject) ORDER BY orderq1.object asc  ) AS rootq  \n                                                     ^"
        },
        {
            "@type": "grpc-status-details-bin",
            "data": "<Unknown Binary Data>"
        },
        {
            "@type": "grpc-server-stats-bin",
            "data": "<Unknown Binary Data>"
        }w
    ]
}
```

Related to task:

https://oat-sa.atlassian.net/wiki/spaces/~682194921/pages/287440902/NEX-778+-+notfication-schema+applied#query-fix-proposal

https://oat-sa.atlassian.net/browse/NEX-778

This is a blocker for https://github.com/oat-sa/tao-core/pull/2431