### PR TITLE
Fix/nex 778/spanner lib generis search errors

### DIFF
--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -179,7 +179,7 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
             $this->query .=  $this->getDriverEscaper()->dbCommand('AND') . ' '.
                 $this->getDriverEscaper()->reserved('modelid') . ' '.
                 $this->getDriverEscaper()->dbCommand('IN') . ' '.
-                "('" . implode("','", $this->model->getReadableModels()) . "')".
+                '(' . implode(',', $this->model->getReadableModels()) . ')'.
                 $this->operationSeparator ;
         }
         $this->query .= ' )'.')';
@@ -264,7 +264,7 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
         foreach ($aliases as $alias) {
             $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
                     $this->getDriverEscaper()->reserved('object') . ' ' .
-                    $this->getDriverEscaper()->dbCommand('AS') . ' ' . $alias['name'] . '_field';
+                    $this->getDriverEscaper()->dbCommand('AS') . ' ' . $alias['name'];
         }
 
         $result .= implode($this->getDriverEscaper()->getFieldsSeparator(), $sortFields)

--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -285,9 +285,8 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
         $sortFields = [];
 
         foreach ($aliases as $alias) {
-            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
-                    $this->getDriverEscaper()->reserved('object') . ' ' .
-                    $alias['dir'] . $this->operationSeparator;
+            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . ' '
+                . $alias['dir'] . $this->operationSeparator;
         }
 
         $result = $this->getDriverEscaper()->dbCommand('ORDER BY') . ' ' .

--- a/src/DbSql/TaoRdf/UnionQuerySerialyser.php
+++ b/src/DbSql/TaoRdf/UnionQuerySerialyser.php
@@ -263,8 +263,7 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
 
         foreach ($aliases as $alias) {
             $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
-                    $this->getDriverEscaper()->reserved('object') . ' ' .
-                    $this->getDriverEscaper()->dbCommand('AS') . ' ' . $alias['name'];
+                    $this->getDriverEscaper()->reserved('object') . ' ';
         }
 
         $result .= implode($this->getDriverEscaper()->getFieldsSeparator(), $sortFields)
@@ -285,8 +284,9 @@ class UnionQuerySerialyser extends AbstractSqlQuerySerialyser {
         $sortFields = [];
 
         foreach ($aliases as $alias) {
-            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . ' '
-                . $alias['dir'] . $this->operationSeparator;
+            $sortFields[] = $this->getDriverEscaper()->reserved($alias['name']) . '.' .
+                    $this->getDriverEscaper()->reserved('object') . ' ' .
+                    $alias['dir'] . $this->operationSeparator;
         }
 
         $result = $this->getDriverEscaper()->dbCommand('ORDER BY') . ' ' .


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-778
Not really related to taoCore itself, but is the must for an installation success. 

_postgresql based instance:_ http://test-lib-search.playground.kitchen.it.taocloud.org:44821/ deployed here ( http://playground.kitchen.it.taocloud.org/?p=test-lib-search_delivery.git;a=summary see details) 

_mysql based instance:_ creation should be fixed as per https://oat-sa.atlassian.net/servicedesk/customer/portal/21/OSD-1161